### PR TITLE
fix: polyfill Object.assign in published code

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/SalesVista/strings#readme",
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-env": "^1.7.0",
     "coveralls": "^3.0.2",
     "standard": "^12.0.1",
@@ -34,6 +35,9 @@
   "babel": {
     "presets": [
       "env"
+    ],
+    "plugins": [
+      "transform-object-assign"
     ]
   }
 }


### PR DESCRIPTION
For better browser compatibility, use a Babel plugin to polyfill `Object.assign()`.