### PR TITLE
feat: parse Accept-Language format in normalizeLocale

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,15 @@ Returns a boolean indicating whether the given string is uppercase (in the given
 
 ### `Strings.normalizeLocale(locale)`
 
-Naively attempts to normalize the given locale string into the language tag format expected by [`toLocaleUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase) or [`toLocaleLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase), by replacing underscores with hyphens.
+Attempts to normalize the given locale string into the format expected by [`toLocaleUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase) or [`toLocaleLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase).
+
+POSIX locales are converted to a [BCP 47](https://tools.ietf.org/html/bcp47) language tag by replacing underscores with hyphens.
 
 E.g. turns `'en_US'` into `'en-US'`
+
+String values in `Accept-Language` header format are also handled such that the first locale encountered with the greatest [quality value](https://developer.mozilla.org/en-US/docs/Glossary/quality_values) will be returned. A value of `'*'` will be ignored.
+
+E.g. turns `'fr-CH,fr;q=0.9,en;q=0.8,de;q=0.7,*;q=0.5'` into `'fr-CH'`
 
 ### `Strings.pluralize(count, noun, opts)`
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-preset-env": "^1.7.0",
     "coveralls": "^3.0.2",
     "standard": "^12.0.1",
-    "standard-version": "^4.4.0",
+    "standard-version": "^5.0.0",
     "tap": "^12.5.2"
   },
   "babel": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,21 @@
 class Strings {
   static normalizeLocale (locale) {
     if (!locale) return undefined
-    return String(locale).replace(/_/g, '-')
+
+    // split on comma, map to value + q, find first highest q, grab value
+    let tokens
+    locale = String(locale).split(',').map(l => {
+      tokens = l.trim().split(';')
+      return {
+        l: tokens[0].trim(),
+        q: (tokens[1] && Number(tokens[1].replace('q', '').replace('=', ''))) || 1
+      }
+    }).reduce((a, o) => {
+      return (o.l && o.l !== '*' && (!a.l || o.q > a.q)) ? o : a
+    }, { q: 0 }).l
+
+    // then replace _ with -
+    return locale && locale.replace(/_/g, '-')
   }
 
   static toUpper (s, locale) {

--- a/test.js
+++ b/test.js
@@ -7,6 +7,20 @@ tap.test('normalizeLocale', t => {
   t.strictEqual(Strings.normalizeLocale(''), undefined)
   t.strictEqual(Strings.normalizeLocale('en-US'), 'en-US')
   t.strictEqual(Strings.normalizeLocale('en_US'), 'en-US')
+
+  t.strictEqual(Strings.normalizeLocale('fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5'), 'fr-CH')
+  t.strictEqual(Strings.normalizeLocale('fr-CH,fr;q=0.9,en;q=0.8,de;q=0.7,*;q=0.5'), 'fr-CH')
+  t.strictEqual(Strings.normalizeLocale('fr,fr-CH;q=0.9,en;q=0.8,de;q=0.7,*;q=0.5'), 'fr')
+
+  t.strictEqual(Strings.normalizeLocale('fr ; q = 0.9 , en_US; q=1, en;q =1 ,*'), 'en-US')
+  t.strictEqual(Strings.normalizeLocale('*,en'), 'en')
+  t.strictEqual(Strings.normalizeLocale('*, en'), 'en')
+  t.strictEqual(Strings.normalizeLocale('* ,en'), 'en')
+  t.strictEqual(Strings.normalizeLocale('* ,en;q'), 'en')
+  t.strictEqual(Strings.normalizeLocale('* ,en;q='), 'en')
+  t.strictEqual(Strings.normalizeLocale('* ,en;q=0'), 'en')
+  t.strictEqual(Strings.normalizeLocale('*'), undefined)
+
   t.end()
 })
 


### PR DESCRIPTION
This PR makes the static `Strings.normalizeLocale` method more robust so that it can parse values in expected Accept-Language header format, choosing the first locale encountered with the greatest [quality value](https://developer.mozilla.org/en-US/docs/Glossary/quality_values) and then normalizing that into a value suitable for use with `String#toLocaleUpperCase()`, `String#toLocaleLowerCase()`, or `new Intl.NumberFormat()`.

This logic also makes `normalizeLocale` suitable for picking out a locale value to store (for background job purposes) for a user.

Also bumping `standard-version` dev dependency, which was manually tested and still works for cutting new releases.