### PR TITLE
feat: support plural opt in pluralize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ Combine the given count and noun into a single formatted string, pluralizing the
 
 Supported options include:
 
-- `suffix` (string): add this to the string instead of making a best-guess effort when pluralization is needed
+- `plural` (string): string to use as plural noun when needed (mutually exclusive with `suffix`)
+- `suffix` (string): add this to the string instead of making a best-guess effort when pluralization is needed (mutually exclusive with `plural`)
 - `locale` (string): to format the integer and respect case-sensitivity in a language-specific way
 
 ### `Strings.toLower(str, locale)`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Each method can also accept an additional options object supporting the followin
 - `lc` (boolean) or `uc` (boolean): to transform the display value to lowercase or uppercase, respectively
 - `abbrev` (boolean): to abbreviate the display value to the first letter of each word in the string
 - `strict` (boolean, default `true`): to use an empty string (strict=true) or key (strict=false) when key not found in strings or defaults
-- `locale` (string): to make sure case-sensitivity respects rules and characters for the user's language and region
+- `locale` (string or array): to make sure case-sensitivity respects rules and characters for the user's language and region
 
 ## Primary API
 
@@ -101,7 +101,7 @@ For convenience, the first two arguments are interchangeable.
 - `uc` (boolean): transform the display string to uppercase (mutually exclusive with `lc`)
 - `abbrev` (boolean): transform the display string to its abbreviated form
 - `strict` (boolean, default `true`): whether keys should be interpreted strictly (required in strings or defaults) or loosely (not required in strings or defaults) - in strict mode, an empty string will be returned when key is not found; in loose mode, the key will be used as the value when key is not found
-- `locale` (string): the user's locale e.g. `'en-US'` or `'en_US'`
+- `locale` (string or array): the user's locale e.g. `'en-US'` or `'en_US'`
 
 ### `Strings.getSingular(strings, key, opts)`
 
@@ -218,7 +218,7 @@ Supported options include:
 
 - `plural` (string): string to use as plural noun when needed (mutually exclusive with `suffix`)
 - `suffix` (string): add this to the string instead of making a best-guess effort when pluralization is needed (mutually exclusive with `plural`)
-- `locale` (string): to format the integer and respect case-sensitivity in a language-specific way
+- `locale` (string or array): to format the integer and respect case-sensitivity in a language-specific way
 
 ### `Strings.toLower(str, locale)`
 
@@ -233,7 +233,7 @@ E.g. turns `'plan'` into `'plans'`, turns `'box'` into `'boxes'`, and turns `'fl
 Supported options include:
 
 - `suffix` (string): add this to the string instead of making a best-guess effort
-- `locale` (string): to respect case-sensitivity in a language-specific way
+- `locale` (string or array): to respect case-sensitivity in a language-specific way
 
 ### `Strings.toUpper(str, locale)`
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,15 +78,19 @@ class Strings {
     noun = String(noun)
     if (typeof count !== 'number') count = Number(count)
     if (Number.isNaN(count)) count = 0
-    let suffix, locale
+    let suffix, locale, plural
     if (typeof opts === 'string') {
       suffix = opts
     } else {
       opts = opts || {}
       suffix = opts.suffix
       locale = opts.locale
+      plural = opts.plural || opts.other
     }
-    return Strings.formatInt(count, locale) + ' ' + (count !== 1 ? Strings.toPlural(noun, { suffix, locale }) : noun)
+    if (count !== 1) {
+      noun = plural || Strings.toPlural(noun, { suffix, locale })
+    }
+    return Strings.formatInt(count, locale) + ' ' + noun
   }
 
   static abbreviate (str) {

--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,10 @@ class Strings {
     } else if (typeof val !== 'string' && (val.singular || val.one)) {
       val = val.singular || val.one
     }
-    if (typeof val !== 'string') return ''
+    if (typeof val !== 'string') {
+      if (opts.strict) return ''
+      val = key
+    }
     // should now have val to use, apply transformational opts
     if (opts.lc) val = Strings.toLower(val, locale)
     else if (opts.uc) val = Strings.toUpper(val, locale)

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ class Strings {
 
     // split on comma, map to value + q, find first highest q, grab value
     let tokens
-    locale = String(locale).split(',').map(l => {
+    locale = [].concat(locale).filter(Boolean).join(',').split(',').map(l => {
       tokens = l.trim().split(';')
       return {
         l: tokens[0].trim(),

--- a/test.js
+++ b/test.js
@@ -37,6 +37,7 @@ tap.test('toUpper', t => {
   t.strictEqual(Strings.toUpper('abc', 'en-US'), 'ABC')
   t.strictEqual(Strings.toUpper('abc', 'en_US'), 'ABC')
   t.strictEqual(Strings.toUpper('abc', 'invalid locale'), 'ABC')
+  t.strictEqual(Strings.toUpper('abc', ['en-US', 'invalid locale']), 'ABC')
   t.strictEqual(Strings.toUpper('лександра'), 'ЛЕКСАНДРА')
   t.strictEqual(Strings.toUpper('łukasz'), 'ŁUKASZ')
   t.end()
@@ -50,6 +51,7 @@ tap.test('toLower', t => {
   t.strictEqual(Strings.toLower('ABC', 'en-US'), 'abc')
   t.strictEqual(Strings.toLower('ABC', 'en_US'), 'abc')
   t.strictEqual(Strings.toLower('ABC', 'invalid locale'), 'abc')
+  t.strictEqual(Strings.toLower('ABC', ['en-US', 'invalid locale']), 'abc')
   t.strictEqual(Strings.toLower('ЛЕКСАНДРА'), 'лександра')
   t.strictEqual(Strings.toLower('ŁUKASZ'), 'łukasz')
   t.end()
@@ -67,6 +69,8 @@ tap.test('isUpper', t => {
   t.strictEqual(Strings.isUpper('A', 'en_US'), true)
   t.strictEqual(Strings.isUpper('a', 'invalid locale'), false)
   t.strictEqual(Strings.isUpper('A', 'invalid locale'), true)
+  t.strictEqual(Strings.isUpper('a', ['en-US', 'invalid locale']), false)
+  t.strictEqual(Strings.isUpper('A', ['en-US', 'invalid locale']), true)
   t.strictEqual(Strings.isUpper('л'), false)
   t.strictEqual(Strings.isUpper('ł'), false)
   t.strictEqual(Strings.isUpper('Л'), true)
@@ -96,9 +100,11 @@ tap.test('toPlural', t => {
   t.strictEqual(Strings.toPlural('plan', { locale: 'en-US' }), 'plans')
   t.strictEqual(Strings.toPlural('plan', { locale: 'en_US' }), 'plans')
   t.strictEqual(Strings.toPlural('plan', { locale: 'invalid locale' }), 'plans')
+  t.strictEqual(Strings.toPlural('plan', { locale: ['en-US', 'invalid locale'] }), 'plans')
   t.strictEqual(Strings.toPlural('PLAN', { locale: 'en-US' }), 'PLANS')
   t.strictEqual(Strings.toPlural('PLAN', { locale: 'en_US' }), 'PLANS')
   t.strictEqual(Strings.toPlural('PLAN', { locale: 'invalid locale' }), 'PLANS')
+  t.strictEqual(Strings.toPlural('PLAN', { locale: ['en-US', 'invalid locale'] }), 'PLANS')
 
   t.strictEqual(Strings.toPlural('plan', { suffix: 'tain' }), 'plantain')
   t.strictEqual(Strings.toPlural('PLAN', { suffix: 'tain' }), 'PLANTAIN')
@@ -109,6 +115,7 @@ tap.test('toPlural', t => {
   t.strictEqual(Strings.toPlural('PLAN', { locale: 'en_US', suffix: 'tain' }), 'PLANTAIN')
   t.strictEqual(Strings.toPlural('plan', { locale: 'invalid locale', suffix: 'tain' }), 'plantain')
   t.strictEqual(Strings.toPlural('PLAN', { locale: 'invalid locale', suffix: 'tain' }), 'PLANTAIN')
+  t.strictEqual(Strings.toPlural('plan', { locale: ['en-US', 'invalid locale'], suffix: 'tain' }), 'plantain')
 
   t.end()
 })
@@ -150,6 +157,8 @@ tap.test('formatInt', t => {
   t.strictEqual(Strings.formatInt('x', 'invalid locale'), 'x')
   t.strictEqual(Strings.formatInt('9e10', 'invalid locale'), '9e10')
   t.strictEqual(Strings.formatInt(Infinity, 'invalid locale'), 'Infinity')
+
+  t.strictEqual(Strings.formatInt(1234567, ['en_US', 'invalid locale']), '1,234,567')
 
   t.end()
 })
@@ -233,6 +242,8 @@ tap.test('pluralize', t => {
 
   t.strictEqual(Strings.pluralize(1000, 'guy', { suffix: 's', locale: 'invalid locale' }), '1000 guys')
   t.strictEqual(Strings.pluralize(1000, 'GUY', { suffix: 's', locale: 'invalid locale' }), '1000 GUYS')
+
+  t.strictEqual(Strings.pluralize(1000, 'guy', { suffix: 's', locale: ['en-US', 'invalid locale'] }), '1,000 guys')
 
   t.strictEqual(Strings.pluralize('2', 'plan'), '2 plans')
   t.strictEqual(Strings.pluralize('xyz', 'plan'), '0 plans')
@@ -402,6 +413,8 @@ tap.test('static get', t => {
   t.strictEqual(Strings.get(invalidKey, strings, { count: 0, locale: 'en-US' }), '')
   t.strictEqual(Strings.get(strings, invalidKey, { count: 2, locale: 'en_US' }), '')
   t.strictEqual(Strings.get(invalidKey, strings, { count: 2, locale: 'en-US' }), '')
+
+  t.strictEqual(Strings.get(strings, Strings.PLAN, { count: 2, locale: ['en_US', 'invalid locale'] }), 'Programs')
 
   // 3rd arg opts object with uc boolean and abbrev boolean
   t.strictEqual(Strings.get(strings, Strings.GROSS_MARGIN, { uc: true, abbrev: true }), 'P')
@@ -685,7 +698,7 @@ tap.test('instance getPlural', t => {
 
 tap.test('extra cases', t => {
   const w = Strings.wrap({
-    locale: 'en-US',
+    locale: ['en-US,en-AU;q=0.8', '*'],
     strings: {
       [Strings.PRODUCT]: {
         singular: 'Product'

--- a/test.js
+++ b/test.js
@@ -21,6 +21,11 @@ tap.test('normalizeLocale', t => {
   t.strictEqual(Strings.normalizeLocale('* ,en;q=0'), 'en')
   t.strictEqual(Strings.normalizeLocale('*'), undefined)
 
+  t.strictEqual(Strings.normalizeLocale(['en;q=0.8', 'fr-CH, fr;q=0.9', 'de;q=0.7,*;q=0.5']), 'fr-CH')
+  t.strictEqual(Strings.normalizeLocale(['*', '', null, undefined, 'en;q=0.8']), 'en')
+  t.strictEqual(Strings.normalizeLocale(['*']), undefined)
+  t.strictEqual(Strings.normalizeLocale([]), undefined)
+
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -411,11 +411,10 @@ tap.test('static get', t => {
 
   const p = {
     person: {
-      singular: 'person',
       plural: 'people'
     }
   }
-  t.strictEqual(Strings.get(p, 'person', { count: 1 }), 'person')
+  t.strictEqual(Strings.get(p, 'person', { count: 1, strict: false }), 'person') // strict=false will fallback to key as singular
   t.strictEqual(Strings.get(p, 'person', { count: 2 }), 'people')
 
   // strings object supports wrapper

--- a/test.js
+++ b/test.js
@@ -232,6 +232,17 @@ tap.test('pluralize', t => {
   t.strictEqual(Strings.pluralize('2', 'plan'), '2 plans')
   t.strictEqual(Strings.pluralize('xyz', 'plan'), '0 plans')
 
+  t.strictEqual(Strings.pluralize(1, 'person', { plural: 'people' }), '1 person')
+  t.strictEqual(Strings.pluralize(1, 'person', { other: 'people' }), '1 person')
+  t.strictEqual(Strings.pluralize(1000, 'person', { plural: 'people' }), '1,000 people')
+  t.strictEqual(Strings.pluralize(1000, 'person', { other: 'people' }), '1,000 people')
+  t.strictEqual(Strings.pluralize(1, 'PERSON', { plural: 'people' }), '1 PERSON')
+  t.strictEqual(Strings.pluralize(1, 'PERSON', { other: 'people' }), '1 PERSON')
+  t.strictEqual(Strings.pluralize(1000, 'PERSON', { plural: 'people' }), '1,000 people')
+  t.strictEqual(Strings.pluralize(1000, 'PERSON', { other: 'people' }), '1,000 people')
+  t.strictEqual(Strings.pluralize(1000, 'PERSON', { plural: 'PEOPLE' }), '1,000 PEOPLE')
+  t.strictEqual(Strings.pluralize(1000, 'PERSON', { other: 'PEOPLE' }), '1,000 PEOPLE')
+
   t.end()
 })
 
@@ -404,8 +415,8 @@ tap.test('static get', t => {
       plural: 'people'
     }
   }
-  t.strictEqual(Strings.get(p, 'person', { count: 1, strict: false }), 'person')
-  t.strictEqual(Strings.get(p, 'person', { count: 2, strict: false }), 'people')
+  t.strictEqual(Strings.get(p, 'person', { count: 1 }), 'person')
+  t.strictEqual(Strings.get(p, 'person', { count: 2 }), 'people')
 
   // strings object supports wrapper
   const wrapper = {


### PR DESCRIPTION
Minor change to make `Strings.pluralize()` a bit more usable for cases where just customizing `suffix` is insufficient, like person vs people.

Also includes a minor fix to fallback to key as singular value (in non-strict mode) when an object without a singular value is defined.

Also includes support for `locale` as an array of values, similar to `navigator.languages`.