### PR TITLE
feat: add `includeCount` option to pluralize method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .nyc_output
 package-lock.json
 lib
+coverage

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Supported options include:
 
 - `plural` (string): string to use as plural noun when needed (mutually exclusive with `suffix`)
 - `suffix` (string): add this to the string instead of making a best-guess effort when pluralization is needed (mutually exclusive with `plural`)
+- `includeCount` (boolean, default `true`): include the formatted count in the returned string
 - `locale` (string or array): to format the integer and respect case-sensitivity in a language-specific way
 
 ### `Strings.toLower(str, locale)`

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "pretest": "standard && npm run prepare",
     "test": "tap --cov test.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "html": "nyc report --reporter=html && open coverage/index.html",
     "release": "standard-version"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -71,26 +71,30 @@ class Strings {
   }
 
   // valid opts:
+  // - plural or other (string, no default) to specify the whole plural form of the word rather than just the suffix
   // - suffix (string, default based on str) to customize pluralization
   // - locale (string, no default) to respect user's language + region
+  // - includeCount (boolean, default true) to include the formatted number in the returned string
   static pluralize (count, noun, opts) {
     if (!noun) return ''
     noun = String(noun)
     if (typeof count !== 'number') count = Number(count)
     if (Number.isNaN(count)) count = 0
-    let suffix, locale, plural
+    let suffix, locale, plural, includeCount
     if (typeof opts === 'string') {
       suffix = opts
+      includeCount = true
     } else {
       opts = opts || {}
       suffix = opts.suffix
       locale = opts.locale
       plural = opts.plural || opts.other
+      includeCount = typeof opts.includeCount === 'boolean' ? opts.includeCount : true
     }
     if (count !== 1) {
       noun = plural || Strings.toPlural(noun, { suffix, locale })
     }
-    return Strings.formatInt(count, locale) + ' ' + noun
+    return (includeCount ? Strings.formatInt(count, locale) + ' ' : '') + noun
   }
 
   static abbreviate (str) {

--- a/test.js
+++ b/test.js
@@ -259,6 +259,17 @@ tap.test('pluralize', t => {
   t.strictEqual(Strings.pluralize(1000, 'PERSON', { plural: 'PEOPLE' }), '1,000 PEOPLE')
   t.strictEqual(Strings.pluralize(1000, 'PERSON', { other: 'PEOPLE' }), '1,000 PEOPLE')
 
+  t.strictEqual(Strings.pluralize(1, 'fly', { includeCount: false }), 'fly')
+  t.strictEqual(Strings.pluralize(0, 'fly', { includeCount: false }), 'flies')
+  t.strictEqual(Strings.pluralize(2, 'fly', { includeCount: false }), 'flies')
+  t.strictEqual(Strings.pluralize(1, 'guy', { suffix: 's', includeCount: false }), 'guy')
+  t.strictEqual(Strings.pluralize(0, 'guy', { suffix: 's', includeCount: false }), 'guys')
+  t.strictEqual(Strings.pluralize(2, 'guy', { suffix: 's', includeCount: false }), 'guys')
+  t.strictEqual(Strings.pluralize(1, 'needs', { plural: 'need', includeCount: false }), 'needs')
+  t.strictEqual(Strings.pluralize(1, 'needs', { other: 'need', includeCount: false }), 'needs')
+  t.strictEqual(Strings.pluralize(1000, 'needs', { plural: 'need', includeCount: false }), 'need')
+  t.strictEqual(Strings.pluralize(1000, 'needs', { other: 'need', includeCount: false }), 'need')
+
   t.end()
 })
 


### PR DESCRIPTION
To make the utility method more useful (e.g. for verbs) in application code.