### PR TITLE
feat: add includeCount option to Strings.get

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ For convenience, the first two arguments are interchangeable.
 
 - `plural` (boolean): whether to use the plural form or not (mutually exclusive with `count`)
 - `count` (number): number of items that should be translated for plurality (mutually exclusive with `plural`)
+- `includeCount` (boolean, default `false`): whether to include `count` as a formatted integer in the returned string (ignored if `count` is not given as a number)
 - `suffix` (string): a custom suffix to add to the display string value when plurality is needed and no explicit plural value is defined
 - `lc` (boolean): transform the display string to lowercase (mutually exclusive with `uc`)
 - `uc` (boolean): transform the display string to uppercase (mutually exclusive with `lc`)

--- a/src/index.js
+++ b/src/index.js
@@ -137,6 +137,7 @@ class Strings {
   // - locale (string, no default) to respect user's language + region
   // - min (integer, no default) to specify the minimum number of chars returned (if possible) when abbreviation is used
   // - max (integer, no default) to specify the maximum number of chars allowed before abbreviation is used
+  // - includeCount (boolean, default false) to include count as formatted integer in returned string (requires count option)
   static get (strings, key, opts) {
     // allow first two args to be interchangeable
     if (typeof strings === 'string') {
@@ -168,6 +169,19 @@ class Strings {
 
     // check for locale
     const locale = opts.locale || strings.locale
+
+    // if includeCount and count given, use pluralize to include formatted integer
+    if (opts.includeCount === true && typeof opts.count === 'number') {
+      return Strings.pluralize(
+        opts.count,
+        Strings.get(strings, key, Object.assign({}, opts, { includeCount: false, plural: false })),
+        {
+          locale,
+          plural: Strings.get(strings, key, Object.assign({}, opts, { includeCount: false, plural: true }))
+        }
+      )
+    }
+
     // determine plurality
     let usePlural = false
     if (typeof opts.plural === 'boolean') usePlural = opts.plural

--- a/test.js
+++ b/test.js
@@ -483,6 +483,31 @@ tap.test('static get', t => {
   t.strictEqual(Strings.get(strings, Strings.QUOTA, { min: 3, max: 3, count: 2 }), 'Pln')
   t.strictEqual(Strings.get(strings, Strings.QUOTA, { min: 4, max: 4, count: 2 }), 'Plns')
 
+  // includeCount option
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 1, includeCount: true }), '1 Sale')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 0, includeCount: true }), '0 Sales')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 1234, includeCount: true }), '1,234 Sales')
+  t.strictEqual(Strings.get(null, 'guy', { count: 1, includeCount: true, suffix: 's', strict: false }), '1 guy')
+  t.strictEqual(Strings.get(null, 'guy', { count: 0, includeCount: true, suffix: 's', strict: false }), '0 guys')
+  t.strictEqual(Strings.get(null, 'guy', { count: 12345, includeCount: true, suffix: 's', strict: false }), '12,345 guys')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 1, includeCount: true, uc: true, abbrev: true }), '1 SAL')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 0, includeCount: true, uc: true, abbrev: true }), '0 SLS')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 123456, includeCount: true, uc: true, abbrev: true }), '123,456 SLS')
+  t.strictEqual(Strings.get(strings, Strings.QUOTA, { count: 1, includeCount: true, lc: true }), '1 plan')
+  t.strictEqual(Strings.get(strings, Strings.QUOTA, { count: 0, includeCount: true, lc: true }), '0 plans')
+  t.strictEqual(Strings.get(strings, Strings.QUOTA, { count: 1234567, includeCount: true, lc: true }), '1,234,567 plans')
+  t.strictEqual(Strings.get(strings, Strings.PLAN, { count: 1, includeCount: true, min: 6, max: 6 }), '1 Prgrm')
+  t.strictEqual(Strings.get(strings, Strings.PLAN, { count: 0, includeCount: true, min: 6, max: 6 }), '0 Prgrms')
+  t.strictEqual(Strings.get(strings, Strings.PLAN, { count: 123, includeCount: true, min: 6, max: 6 }), '123 Prgrms')
+  // includeCount ignored if count is not given
+  t.strictEqual(Strings.get(strings, Strings.PRODUCT, { plural: true, includeCount: true, lc: true }), 'products')
+  // includeCount ignored if count is not a number
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: '1234', includeCount: true }), 'Sale')
+  // includeCount can also be false
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 1, includeCount: false }), 'Sale')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 0, includeCount: false }), 'Sales')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { count: 1234, includeCount: false }), 'Sales')
+
   const p = {
     person: {
       plural: 'people'


### PR DESCRIPTION
Add support for a `includeCount: true` option to `Strings.get(strings, key, opts)`.

This option is a shortcut (with better `locale` support) for the following, which came up recently in web app usage as we expand the amount of customizable strings in the SalesVista app:

```js
// let numSales = 1234
Strings.pluralize(
  numSales,
  Strings.get(customStrings, Strings.SALE, { lc: true }),
  { plural: Strings.getPlural(customStrings, Strings.SALE, { plural: true, lc: true }) }
)
//=> 1,234 sales
```

After this PR, the above can be simplified to this:

```js
// let numSales = 1234
Strings.get(customStrings, Strings.SALE, { count: numSales, includeCount: true, lc: true })
//=> 1,234 sales
```

Assumes that `count` should be formatted _as an integer_ and included in the returned (customizable) string.

The `includeCount` option is ignored if `count` is not given or if `count` is not a number.

If `count: num` and `includeCount: true` are given, then those options will take precedence over a `plural: true/false` option.

Otherwise, all other options are preserved.