### PR TITLE
feat: add withArticle option and secondary api

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ For convenience, the first two arguments are interchangeable.
 - `abbrev` (boolean): transform the display string to its abbreviated form
 - `max` (number): conditionally abbreviate the display string if it has more than this number of characters
 - `min` (number): if abbreviation is required, this specifies the desired number of characters for the abbreviation (only applies to single-word display strings) - internally passed as the 2nd argument to `Strings.abbreviate(str, singleWordSize)`, see docs there
+- `withArticle` (boolean, default `false`): whether to prefix the custom string with "a" or "an", based on if the custom string starts with a vowel (aeiou) or not
+- `consonant` (string): customize the article used as a prefix when `withArticle` is `true` and the custom string starts with a consonant - the given string will be used instead of "a"
+- `vowel` (string): customize the article used as a prefix when `withArticle` is `true` and the custom string starts with a vowel - the given string will be used instead of "an"
 - `strict` (boolean, default `true`): whether keys should be interpreted strictly (required in strings or defaults) or loosely (not required in strings or defaults) - in strict mode, an empty string will be returned when key is not found; in loose mode, the key will be used as the value when key is not found
 - `locale` (string or array): the user's locale e.g. `'en-US'` or `'en_US'`
 
@@ -206,6 +209,14 @@ Attempts to format the given integer into a string per the given locale.
 
 Returns a boolean indicating whether the given string is uppercase (in the given locale) or not.
 
+### `Strings.isVowel(char, includeY = true)`
+
+Returns a boolean indicating if the given character is a vowel or not.
+
+By default, "y" is considered a vowel; to exclude "y", pass `false` as the 2nd argument.
+
+If you pass a string with more than one character for the 1st argument, this function performs a "contains vowel" check.
+
 ### `Strings.normalizeLocale(locale)`
 
 Attempts to normalize the given locale string into the format expected by [`toLocaleUpperCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase) or [`toLocaleLowerCase`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase).
@@ -229,6 +240,12 @@ Supported options include:
 - `includeCount` (boolean, default `true`): include the formatted count in the returned string
 - `locale` (string or array): to format the integer and respect case-sensitivity in a language-specific way
 
+### `Strings.startsWithVowel(str)`
+
+Returns a boolean indicating if the given string starts with a vowel.
+
+Note that "y" is not considered a vowel by this function.
+
 ### `Strings.toLower(str, locale)`
 
 Attempts to safely transform the given string into lowercase. If a locale is given, it will be normalized. If the locale-specific operation fails, it will fall back to a locale-agnostic operation.
@@ -247,6 +264,17 @@ Supported options include:
 ### `Strings.toUpper(str, locale)`
 
 Attempts to safely transform the given string into uppercase. If a locale is given, it will be normalized. If the locale-specific operation fails, it will fall back to a locale-agnostic operation.
+
+### `Strings.withArticle(str, opts)`
+
+Return the given string prefixed with an appropriate article - either "a" (for strings starting with a consonant) or "an" (for strings starting with a vowel). E.g. turns "sale" into "a sale", or "event" into "an event".
+
+If the given string starts with an uppercase letter, the first letter of the article will be transformed to uppercase as well.
+
+Supports the following options:
+- `consonant` (string, default `'a'`): customize the article used for strings starting with a consonant
+- `vowel` (string, default `'an'`): customize the article used for strings starting with a vowel
+- `locale` (string or array): to respect case-sensitivity in a language-specific way
 
 ## Releasing
 

--- a/test.js
+++ b/test.js
@@ -292,6 +292,64 @@ tap.test('pluralize', t => {
   t.end()
 })
 
+tap.test('isVowel', t => {
+  t.strictEqual(Strings.isVowel(), false)
+  t.strictEqual(Strings.isVowel(null), false)
+  t.strictEqual(Strings.isVowel(''), false)
+  t.strictEqual(Strings.isVowel('s'), false)
+  t.strictEqual(Strings.isVowel('S'), false)
+  t.strictEqual(Strings.isVowel('a'), true)
+  t.strictEqual(Strings.isVowel('A'), true)
+  t.strictEqual(Strings.isVowel('e'), true)
+  t.strictEqual(Strings.isVowel('E'), true)
+  t.strictEqual(Strings.isVowel('i'), true)
+  t.strictEqual(Strings.isVowel('I'), true)
+  t.strictEqual(Strings.isVowel('o'), true)
+  t.strictEqual(Strings.isVowel('O'), true)
+  t.strictEqual(Strings.isVowel('u'), true)
+  t.strictEqual(Strings.isVowel('U'), true)
+  t.strictEqual(Strings.isVowel('y'), true)
+  t.strictEqual(Strings.isVowel('Y'), true)
+  t.strictEqual(Strings.isVowel('y', false), false)
+  t.strictEqual(Strings.isVowel('Y', false), false)
+  t.strictEqual(Strings.isVowel('abc'), true) // acts like "contains vowel"
+  t.strictEqual(Strings.isVowel('cab'), true) // acts like "contains vowel"
+  t.strictEqual(Strings.isVowel(0), false)
+  t.strictEqual(Strings.isVowel(1), false)
+  t.strictEqual(Strings.isVowel(2), false)
+  t.end()
+})
+
+tap.test('startsWithVowel', t => {
+  t.strictEqual(Strings.startsWithVowel(), false)
+  t.strictEqual(Strings.startsWithVowel(null), false)
+  t.strictEqual(Strings.startsWithVowel(''), false)
+  t.strictEqual(Strings.startsWithVowel('sale'), false)
+  t.strictEqual(Strings.startsWithVowel('Sale'), false)
+  t.strictEqual(Strings.startsWithVowel('event'), true)
+  t.strictEqual(Strings.startsWithVowel('Event'), true)
+  t.strictEqual(Strings.startsWithVowel('yard'), false)
+  t.strictEqual(Strings.startsWithVowel('Yard'), false)
+  t.end()
+})
+
+tap.test('withArticle', t => {
+  t.strictEqual(Strings.withArticle(), '')
+  t.strictEqual(Strings.withArticle(null), '')
+  t.strictEqual(Strings.withArticle(''), '')
+  t.strictEqual(Strings.withArticle('sale'), 'a sale')
+  t.strictEqual(Strings.withArticle('Sale'), 'A Sale')
+  t.strictEqual(Strings.withArticle('event'), 'an event')
+  t.strictEqual(Strings.withArticle('Event'), 'An Event')
+  t.strictEqual(Strings.withArticle('sale', { consonant: 'the', vowel: 'the' }), 'the sale')
+  t.strictEqual(Strings.withArticle('event', { consonant: 'the', vowel: 'the' }), 'the event')
+  t.strictEqual(Strings.withArticle('Sale', { consonant: 'the', vowel: 'the' }), 'The Sale')
+  t.strictEqual(Strings.withArticle('Event', { consonant: 'the', vowel: 'the' }), 'The Event')
+  t.strictEqual(Strings.withArticle('yard'), 'a yard')
+  t.strictEqual(Strings.withArticle('Yard'), 'A Yard')
+  t.end()
+})
+
 tap.test('abbreviate', t => {
   t.strictEqual(Strings.abbreviate(), '')
   t.strictEqual(Strings.abbreviate(null), '')
@@ -544,6 +602,16 @@ tap.test('static get', t => {
   t.strictEqual(Strings.get(strings, Strings.SALE, { count: 1, includeCount: false }), 'Sale')
   t.strictEqual(Strings.get(strings, Strings.SALE, { count: 0, includeCount: false }), 'Sales')
   t.strictEqual(Strings.get(strings, Strings.SALE, { count: 1234, includeCount: false }), 'Sales')
+
+  // withArticle
+  t.strictEqual(Strings.get(strings, Strings.ADJUSTMENT, { withArticle: true }), 'An Adjustment')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { withArticle: true }), 'A Sale')
+  t.strictEqual(Strings.get(strings, Strings.ADJUSTMENT, { withArticle: true, lc: true }), 'an adjustment')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { withArticle: true, lc: true }), 'a sale')
+  t.strictEqual(Strings.get(strings, Strings.ADJUSTMENT, { withArticle: true, consonant: 'the', vowel: 'the' }), 'The Adjustment')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { withArticle: true, consonant: 'the', vowel: 'the' }), 'The Sale')
+  t.strictEqual(Strings.get(strings, Strings.ADJUSTMENT, { withArticle: true, lc: true, consonant: 'the', vowel: 'the' }), 'the adjustment')
+  t.strictEqual(Strings.get(strings, Strings.SALE, { withArticle: true, lc: true, consonant: 'the', vowel: 'the' }), 'the sale')
 
   const p = {
     person: {


### PR DESCRIPTION
To better support grammar for singular customized strings, this PR adds a `withArticle` boolean option to the primary `Strings.get(strings, key, opts)` API, to easily support the following:

```js
const aThing = Strings.get(customStrings, Strings.SALE, { withArticle: true, lc: true })
const msg = `For ${aThing} to apply to this rule, it must have at least one of the selected labels.`
```

If `Strings.SALE` has not been customized, the result will be `'a sale'`.

If `Strings.SALE` has been customized to `'Event'`, the result will be `'an event'`.

Also adds the following utility functions as part of the secondary API:
- `Strings.isVowel(char, includeY = true)`
- `Strings.startsWithVowel(str)`
- `Strings.withArticle(str, opts)`

See README for further details.