### PR TITLE
feat: add Transaction Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Shortcut to get the plural value defined for `key`. If a singular value is defin
 - `Strings.RULE`
 - `Strings.SALE`
 - `Strings.TEAM`
+- `Strings.TRANSACTION_DATE`
 - `Strings.UNIT`
 - `Strings.VOLUME`
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prepare": "babel src -d lib",
     "pretest": "standard && npm run prepare",
-    "test": "tap --cov test.js",
+    "test": "tap --reporter=classic --cov test.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "html": "nyc report --reporter=html && open coverage/index.html",
     "release": "standard-version"

--- a/src/index.js
+++ b/src/index.js
@@ -306,6 +306,7 @@ Strings.PLAN = 'plan'
 Strings.QUOTA = 'quota'
 Strings.RULE = 'rule'
 Strings.SALE = 'sale'
+Strings.TRANSACTION_DATE = 'transaction_date'
 Strings.COMPENSATION = 'compensation'
 Strings.REPORT = 'report'
 Strings.DRAFT = 'draft'
@@ -345,6 +346,7 @@ Strings.DEFAULTS = {
   [Strings.QUOTA]: 'Quota',
   [Strings.RULE]: 'Rule',
   [Strings.SALE]: 'Sale',
+  [Strings.TRANSACTION_DATE]: 'Transaction Date',
   [Strings.COMPENSATION]: {
     singular: 'Compensation',
     plural: 'Compensation'

--- a/test.js
+++ b/test.js
@@ -824,6 +824,7 @@ tap.test('instance get', t => {
   t.strictEqual(s.get(Strings.GROSS_MARGIN, { abbrev: true }), 'Pft')
   t.strictEqual(d.get(Strings.ANNUAL_CONTRACT_VALUE, { abbrev: true }), 'ACV')
   t.strictEqual(s.get(Strings.ANNUAL_CONTRACT_VALUE, { abbrev: true }), 'ACV')
+  t.strictEqual(d.get(Strings.TRANSACTION_DATE, { abbrev: true }), 'TD')
 
   // 2rd arg object as opts with plural boolean and flu boolean
   t.strictEqual(d.get(Strings.REPORT, { plural: false, flu: true }), 'Report')
@@ -964,6 +965,8 @@ tap.test('defaults', t => {
   t.strictEqual(d.getPlural(Strings.RULE), 'Rules')
   t.strictEqual(d.getSingular(Strings.SALE), 'Sale')
   t.strictEqual(d.getPlural(Strings.SALE), 'Sales')
+  t.strictEqual(d.getSingular(Strings.TRANSACTION_DATE), 'Transaction Date')
+  t.strictEqual(d.getPlural(Strings.TRANSACTION_DATE), 'Transaction Dates')
   t.strictEqual(d.getSingular(Strings.COMPENSATION), 'Compensation')
   t.strictEqual(d.getPlural(Strings.COMPENSATION), 'Compensation')
   t.strictEqual(d.getSingular(Strings.REPORT), 'Report')


### PR DESCRIPTION
## Description
This PR enhances the functionality of the strings library to include `Transaction_Date` as a customizable string.
This will allow our server to verify that the new `Transaction_Date` is a valid string, and for our clients to display the customized string.